### PR TITLE
Fix footer logo class mismatch

### DIFF
--- a/enquete_psd_web/enquete_psd_web/css/styles.css
+++ b/enquete_psd_web/enquete_psd_web/css/styles.css
@@ -414,6 +414,7 @@ ul, ol {
 }
 
 .footer-logo-img {
+    /* Logo displayed in the footer */
     height: 60px;
     width: auto;
 }

--- a/enquete_psd_web/enquete_psd_web/index.html
+++ b/enquete_psd_web/enquete_psd_web/index.html
@@ -466,7 +466,7 @@
     <footer class="footer">
         <div class="container">
             <div class="footer-content">
-                <img src="images/logo-ape.png" alt="Logo APE-LFJP" class="footer-logo">
+                <img src="images/logo-ape.png" alt="Logo APE-LFJP" class="footer-logo-img">
                 <div class="footer-info">
                     <p>Enquête réalisée dans le cadre du Plan Stratégique de Développement du LFJP</p>
                     <p>&copy; 2025 APE-LFJP - Tous droits réservés</p>


### PR DESCRIPTION
## Summary
- update index to use `footer-logo-img`
- document footer logo style in CSS

## Testing
- `npm test` *(fails: no `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6842fe66e16083319f948945fe7097bb